### PR TITLE
replce windows_batch with batch in import_certificate.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of windows_ssl.
 
+## 0.1.1
+* Attribute name changes for Chef 13 compatibility
+
 ## 0.1.0:
 
 * Initial release of windows_ssl

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This cookbook installs and binds SSL certificates on Windows
 Requirements
 ------------
 
-- Windows server 2008  
-- Windows server 2012 (untested)  
+- Windows server 2008 R2
+- Windows server 2012 
+- Windows server 2016 
 
 Cookbooks
 ---------
@@ -46,7 +47,7 @@ bind_certificate
 
 ### Attribute Parameters
 
-- hash: the certificate hash
+- certificate_hash: the certificate hash
 - port: the port
 - ip_address: the ip address to bind to. Defaults to 0.0.0.0 (any ip address)
 - app_guid: the application guid. Defaults to 00000000-0000-0000-0000-000000000000 (any application)
@@ -54,7 +55,7 @@ bind_certificate
 ### Examples
 
     windows_ssl_bind_certificate "bind the ssl cert" do
-        hash '991deaa340c14b45214927f58a8b7288d9ce6906'
+        certificate_hash '991deaa340c14b45214927f58a8b7288d9ce6906'
         port 443
         ip_address '0.0.0.0'
         app_guid '1A25F4DE-A3DE-FEA2-EAF0-023FA1AD324'

--- a/metadata.json
+++ b/metadata.json
@@ -26,5 +26,5 @@
   },
   "recipes": {
   },
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,8 @@
 name             'windows_ssl'
-maintainer       'Standard Edge'
+maintainer       'Paul Christidis'
 maintainer_email ''
 license          'All rights reserved'
 description      'Installs/Configures windows_ssl'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
-depends			 'windows'
+version          '0.1.1'
+depends		 'windows'

--- a/providers/bind_certificate.rb
+++ b/providers/bind_certificate.rb
@@ -3,7 +3,7 @@
 include Chef::Mixin::ShellOut
 
 action :bind do
-	hash = @new_resource.hash
+	certificate_hash = @new_resource.certificate_hash
 	ip_address = @new_resource.ip_address
 	port = @new_resource.port
 	app_guid = @new_resource.app_guid
@@ -18,8 +18,8 @@ action :bind do
     verifyCertificateIsBindable(certificateInfo)
   end
 
-	execute "install ssl certificate #{hash}" do
-		command "netsh http add sslcert ipport=#{ip_address}:#{port} certhash=#{hash} appid={#{app_guid}}"
+	execute "install ssl certificate #{certificate_hash}" do
+		command "netsh http add sslcert ipport=#{ip_address}:#{port} certhash=#{certificate_hash} appid={#{app_guid}}"
     only_if { unbound }
 		action :run
 	end
@@ -59,7 +59,7 @@ def verifyCertificateIsBindable(certificateInfo)
   currentHash = getCurrentCertificateHash(certificateInfo)
   currentAppGuid = getCurrentApplicationGuid(certificateInfo)
   currentIpAddress = getCurrentIpAddress = getCurrentIpAddress(certificateInfo)
-  if(currentHash != @new_resource.hash ||
+  if(currentHash != @new_resource.certificate_hash ||
       currentAppGuid != @new_resource.app_guid ||
       currentIpAddress != @new_resource.ip_address)
     raise "There is already a certificate bound to port #{@new_resource.port}. Conflicting certificate info:\n" + certificateInfo

--- a/providers/import_certificate.rb
+++ b/providers/import_certificate.rb
@@ -3,7 +3,7 @@ include Windows::Helper
 action :import do
   pfxpath = cached_file(@new_resource.path)
 	password = @new_resource.password
-	windows_batch "import certificate #{pfxpath}" do
+	batch "import certificate #{pfxpath}" do
 		code "certutil -p #{password} -importpfx #{pfxpath}"
 		action :run
 	end

--- a/resources/bind_certificate.rb
+++ b/resources/bind_certificate.rb
@@ -1,6 +1,6 @@
 actions :bind
 
-attribute :hash, :kind_of => String
+attribute :certificate_hash, :kind_of => String
 attribute :port, :kind_of => Integer
 attribute :ip_address, :kind_of => String, :default => '0.0.0.0'
 attribute :app_guid, :kind_of => String, :default => '00000000-0000-0000-0000-000000000000'


### PR DESCRIPTION
Hi Matt,

The windows_batch resource has been removed from the windows cookbook, since newer versions of chef 
have a "batch" resource.

This has caused the import_certificate.rb provider to fail with newer versions of the windows cookbook.
I have updated the import_certificate.rb provider to use the new "batch" provider.

Please accept my pull request.

Cheers,
Paul
